### PR TITLE
Backport build fixes

### DIFF
--- a/ci/circleci-build-android.sh
+++ b/ci/circleci-build-android.sh
@@ -19,6 +19,10 @@ uname -m
 if [ -f ~/.config/local-build.rc ]; then source ~/.config/local-build.rc; fi
 if [ -d /ci-source ]; then cd /ci-source; fi
 
+# Handle possible outdated key for google packages, see #487
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+    | sudo apt-key add -
+
 git submodule update --init opencpn-libs
 
 # Set up build directory and a visible link in /

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -44,7 +44,11 @@ if [ -n "$CI" ]; then
     wget -q -O - https://dl.google.com/linux/linux_signing_key.pub \
         | sudo apt-key add -
 
-    # Install flatpak and flatpak-builder
+    # Use updated flatpak (#457)
+    sudo add-apt-repository -y ppa:alexlarsson/flatpak
+    sudo apt update
+
+    # Install or update flatpak and flatpak-builder
     sudo apt install flatpak flatpak-builder
 fi
 

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -39,6 +39,11 @@ if [ -n "$CI" ]; then
     # Avoid using outdated TLS certificates, see #210.
     sudo apt install --reinstall  ca-certificates
 
+    # Handle possible outdated key for google packages, see #486
+    curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
+    wget -q -O - https://dl.google.com/linux/linux_signing_key.pub \
+        | sudo apt-key add -
+
     # Install flatpak and flatpak-builder
     sudo apt install flatpak flatpak-builder
 fi


### PR DESCRIPTION
This pr backports some build fixes from current shipdriver. It builds everything besides android.

As for android, it fails on tons of errors like

    /home/circleci/project/src/JavaScriptgui.h:78:3: error: unknown type name 'wxStyledTextCtrl'
                wxStyledTextCtrl* m_Script;

These looks like source code errors to me i. e., that plugin uses functionality not available in Android. Might be wrong, for sure.